### PR TITLE
Fix imagedestroy deprecation

### DIFF
--- a/fpdf/fpdf.php
+++ b/fpdf/fpdf.php
@@ -1443,7 +1443,6 @@ protected function _parsegif($file)
 	ob_start();
 	imagepng($im);
 	$data = ob_get_clean();
-	imagedestroy($im);
 	$f = fopen('php://temp','rb+');
 	if(!$f)
 		$this->Error('Unable to create memory stream');

--- a/scripts/PDFMemImage/README.md
+++ b/scripts/PDFMemImage/README.md
@@ -81,7 +81,6 @@ imagefilledrectangle($im, 80, 80, 110, 148, $color2);
 imagefilledrectangle($im, 130, 40, 160, 148, $color3);
 // Output it
 $pdf->GDImage($im, 120, 25, 40);
-imagedestroy($im);
 
 $pdf->Output('F', __DIR__ . '/example.pdf');
 ```

--- a/scripts/PDFMemImage/ex.php
+++ b/scripts/PDFMemImage/ex.php
@@ -36,6 +36,5 @@
 	imagefilledrectangle($im, 130, 40, 160, 148, $color3);
 	// Output it
 	$pdf->GDImage($im, 120, 25, 40);
-	imagedestroy($im);
 
 	$pdf->Output('F', __DIR__ . '/example.pdf');

--- a/scripts/QRcode/QRcode.php
+++ b/scripts/QRcode/QRcode.php
@@ -219,7 +219,6 @@ namespace FPDF\Scripts\QRcode;
 				header("Content-type: image/png");
 				imagepng($im);
 			}
-			imagedestroy($im);
 			return true;
 		}
 

--- a/tests/Scripts/PDFMemImageTraitTest.php
+++ b/tests/Scripts/PDFMemImageTraitTest.php
@@ -30,7 +30,6 @@
 			imagefilledrectangle($im, 80, 80, 110, 148, $color2);
 			imagefilledrectangle($im, 130, 40, 160, 148, $color3);
 			$pdf->GDImage($im, 120, 25, 40);
-			imagedestroy($im);
 
 			$this->assertFileCanBeCreated($pdf);
 

--- a/tests/test.php
+++ b/tests/test.php
@@ -306,7 +306,6 @@
 	imagefilledrectangle($im, 80, 80, 110, 148, $color2);
 	imagefilledrectangle($im, 130, 40, 160, 148, $color3);
 	$pdf->GDImage($im, 120, 25, 40);
-	imagedestroy($im);
 
 	//PDFDrawTrait
 	$pdf->SetFont('arial', '', 10);


### PR DESCRIPTION
https://www.php.net/manual/en/function.imagedestroy.php
> **Warning** This function has been _DEPRECATED_ as of PHP 8.5.0. Relying on this function is highly discouraged.
>
> **Note:** This function has no effect. Prior to PHP 8.0.0